### PR TITLE
Allow deletion when doc does not appear to exist.

### DIFF
--- a/FgsSolr2/src/java/dk/defxws/fgssolr/OperationsImpl.java
+++ b/FgsSolr2/src/java/dk/defxws/fgssolr/OperationsImpl.java
@@ -338,11 +338,14 @@ public class OperationsImpl extends GenericOperationsImpl {
     throws java.rmi.RemoteException {
         if (logger.isDebugEnabled())
             logger.debug("deletePid indexName="+indexName+" pid="+pid);
-        if (pid.length()>0 && indexDocExists(pid)) {
+        if (pid.length()>0) {
+            boolean existed = indexDocExists(pid);
             StringBuffer sb = new StringBuffer("<delete><id>"+pid+"</id></delete>");
             postData(config.getIndexBase(indexName)+"/update", new StringReader(sb.toString()), resultXml);
-            deleteTotal++;
-            docCount--;
+            if (existed) {
+              deleteTotal++;
+              docCount--;
+            }
             resultXml.append("<deletePid pid=\""+pid+"\"/>\n");
         }
     }


### PR DESCRIPTION
Should allow deletion from remote Solrs.

...  A local index is still required to satisfy the index reader... The numbers and GUI in the gsearch interface will be inconsistent with the contents of the remote Solr. To do this "properly" (abstracting out index interactions, so we could use a different mechanism for the remote Solr) seems like it would be an much more in-depth task... and we can likely live with the numbers being out-of-whack when using a remote Solr.
